### PR TITLE
OPS_Error -> opserr & Nov22 in Bilin & KgetTangent

### DIFF
--- a/C++ Code/IMKBilin.cpp
+++ b/C++ Code/IMKBilin.cpp
@@ -41,7 +41,7 @@ OPS_IMKBilin(void)
 {
     if (numIMKBilinMaterials == 0) {
         numIMKBilinMaterials++;
-        OPS_Error("IMK with Bilinear Response - Code by AE_KI (Oct22)\n", 1);
+        opserr << "IMK with Bilinear Response - Code by AE_KI (Nov22)\n";
     }
 
     // Pointer to a uniaxial material that will be returned
@@ -119,12 +119,11 @@ int IMKBilin::setTrialStrain(double strain, double strainRate)
     U           = strain; //set trial displacement
     Ui          = U;
     double dU   = Ui - Ui_1;    // Incremental deformation at current step
-    double exKgetTangent = KgetTangent;
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    ////////////////////////////////////////////////////////  MAIN CODE //////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-    //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////  MAIN CODE //////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
     if (Failure_State==5) {     // When a failure has already occured
         Fi  = 0;
     } else if (dU == 0) {   // When deformation doesn't change from the last
@@ -178,7 +177,7 @@ int IMKBilin::setTrialStrain(double strain, double strainRate)
                 posUcap         = posKp <= posKpc ? 0 : (FcapProj - FyProj) / (posKp - posKpc);
                 posFcap         = FyProj + posKp*posUcap;
             // When a part of backbone is beneath the residual strength
-                double candidateKp = (posFcap - posFres) / (posUcap - Ui_1 - (posFres - Fi_1)/Kunload);                
+                double candidateKp = (posFcap - posFres) / (posUcap - Ui_1 - (posFres - Fi_1)/Kunload);
                 if (posFcap < posFres) {
                     posFy   = posFres;
                     posFcap = posFres;
@@ -227,40 +226,32 @@ int IMKBilin::setTrialStrain(double strain, double strainRate)
     ///////////////////////////////////////////////////////////////////////////////////////////
     // Positive
         if (dU > 0) {   // Backbone in Positive
-            KgetTangent = (Ui < posUcap) ? posKp : posKpc;
-            double Fi_backbone = posFcap + (Ui - posUcap) * KgetTangent;
+            double Kbackbone = (Ui < posUcap) ? posKp : posKpc;
+            double Fi_backbone = posFcap + (Ui - posUcap) * Kbackbone;
             if (Fi_backbone < posFres || Failure_State==4) {
                 Fi_backbone = posFres;
-                KgetTangent = 0;
             }
             if (Failure_State==3) {
                 Fi_backbone = 0;
-                KgetTangent = 0;
             }
             if (Fi > Fi_backbone) {
                 Fi = Fi_backbone;
                 onBackbone  = true;
-            } else {
-                KgetTangent = Kunload;
             }
         }
     // Negative
         else {          // Backbone in Negative
-            KgetTangent = (negUcap < Ui) ? negKp : negKpc;
-            double Fi_backbone = negFcap + (Ui - negUcap) * KgetTangent;
+            double Kbackbone = (negUcap < Ui) ? negKp : negKpc;
+            double Fi_backbone = negFcap + (Ui - negUcap) * Kbackbone;
             if (Fi_backbone > negFres || Failure_State==3) {
                 Fi_backbone = negFres;
-                KgetTangent = 0;
             }
             if (Failure_State==4) {
                 Fi_backbone = 0;
-                KgetTangent = 0;
             }
             if (Fi < Fi_backbone) {
                 Fi = Fi_backbone;
                 onBackbone  = true;
-            } else {
-                KgetTangent = Kunload;
             }
         }
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -323,9 +314,7 @@ int IMKBilin::setTrialStrain(double strain, double strainRate)
 
         engAcml += 0.5*(Fi + Fi_1)*dU;   // Internal energy increment
 
-        if (KgetTangent!=exKgetTangent) {
-            KgetTangent  = (Fi - Fi_1) / dU;
-        }
+        KgetTangent  = (Fi - Fi_1) / dU;
     }
     if (KgetTangent==0) {
         KgetTangent  = 1e-6;
@@ -473,8 +462,9 @@ int IMKBilin::revertToStart(void)
     U	        = cU	        = 0;
     Ui      	= cUi 	        = 0;
     Fi 	        = cFi 	        = 0;
-// 1 Stiffness
+// 2 Stiffness
     Kunload	    = cKunload	    = Ke;
+    KgetTangent = Ke;
 // 2 Energy
     engAcml 	= cEngAcml	    = 0.0;
     engDspt	    = cEngDspt	    = 0.0;

--- a/C++ Code/IMKPeakOriented.cpp
+++ b/C++ Code/IMKPeakOriented.cpp
@@ -39,24 +39,24 @@ static int numIMKPeakOrientedMaterials = 0;
 void *
 OPS_IMKPeakOriented()
 {
-	if (numIMKPeakOrientedMaterials == 0) {
-		numIMKPeakOrientedMaterials++;
-		OPS_Error("IMK with Peak-Oriented Response - Code by AE_KI (Oct22)\n", 1);
-	}
+    if (numIMKPeakOrientedMaterials == 0) {
+        numIMKPeakOrientedMaterials++;
+        opserr << "IMK with Peak-Oriented Response - Code by AE_KI (Nov22)\n";
+    }
 
-	// Pointer to a uniaxial material that will be returned
-	UniaxialMaterial *theMaterial = 0;
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial *theMaterial = 0;
 
-	int    iData[1];
-	double dData[23];
-	int numData = 1;
+    int    iData[1];
+    double dData[23];
+    int numData = 1;
 
-	if (OPS_GetIntInput(&numData, iData) != 0) {
-		opserr << "WARNING invalid uniaxialMaterial IMKPeakOriented tag" << endln;
-		return 0;
-	}
+    if (OPS_GetIntInput(&numData, iData) != 0) {
+        opserr << "WARNING invalid uniaxialMaterial IMKPeakOriented tag" << endln;
+        return 0;
+    }
 
-	numData = 23;
+    numData = 23;
 
 
     if (OPS_GetDoubleInput(&numData, dData) != 0) {
@@ -68,21 +68,20 @@ OPS_IMKPeakOriented()
     }
 
 
+    // Parsing was successful, allocate the material
+    theMaterial = new IMKPeakOriented(iData[0],
+        dData[0],
+        dData[1], dData[2], dData[3], dData[4], dData[5], dData[6],
+        dData[7], dData[8], dData[9], dData[10], dData[11], dData[12],
+        dData[13], dData[14], dData[15], dData[16], dData[17], dData[18], dData[19], dData[20],
+        dData[21], dData[22]);
 
-	// Parsing was successful, allocate the material
-	theMaterial = new IMKPeakOriented(iData[0],
-		dData[0],
-		dData[1], dData[2], dData[3], dData[4], dData[5], dData[6],
-		dData[7], dData[8], dData[9], dData[10], dData[11], dData[12],
-		dData[13], dData[14], dData[15], dData[16], dData[17], dData[18], dData[19], dData[20],
-		dData[21], dData[22]);
+    if (theMaterial == 0) {
+        opserr << "WARNING could not create uniaxialMaterial of type IMKPeakOriented Material\n";
+        return 0;
+    }
 
-	if (theMaterial == 0) {
-		opserr << "WARNING could not create uniaxialMaterial of type IMKPeakOriented Material\n";
-		return 0;
-	}
-
-	return theMaterial;
+    return theMaterial;
 }
 
 IMKPeakOriented::IMKPeakOriented(int tag, double p_Ke,
@@ -94,7 +93,7 @@ IMKPeakOriented::IMKPeakOriented(int tag, double p_Ke,
     negUp_0(p_negUp_0), negUpc_0(p_negUpc_0), negUu_0(p_negUu_0), negFy_0(p_negFy_0), negFcapFy_0(p_negFcapFy_0), negFresFy_0(p_negFresFy_0),
     LAMBDA_S(p_LAMBDA_S), LAMBDA_C(p_LAMBDA_C), LAMBDA_A(p_LAMBDA_A), LAMBDA_K(p_LAMBDA_K), c_S(p_c_S), c_C(p_c_C), c_A(p_c_A), c_K(p_c_K), D_pos(p_D_pos), D_neg(p_D_neg)
 {
-	this->revertToStart();
+    this->revertToStart();
 }
 
 IMKPeakOriented::IMKPeakOriented()
@@ -103,18 +102,18 @@ IMKPeakOriented::IMKPeakOriented()
     negUp_0(0), negUpc_0(0), negUu_0(0), negFy_0(0), negFcapFy_0(0), negFresFy_0(0),
     LAMBDA_S(0), LAMBDA_C(0), LAMBDA_A(0), LAMBDA_K(0), c_S(0), c_C(0), c_A(0), c_K(0), D_pos(0), D_neg(0)
 {
-	this->revertToStart();
+    this->revertToStart();
 }
 
 IMKPeakOriented::~IMKPeakOriented()
 {
-	// does nothing
+    // does nothing
 }
 
 int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
 {
-	//all variables to the last commit
-	this->revertToLastCommit();
+    //all variables to the last commit
+    this->revertToLastCommit();
 
     //state determination algorithm: defines the current force and tangent stiffness
     double Ui_1 = Ui;
@@ -122,7 +121,6 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
     U           = strain; //set trial displacement
     Ui          = U;
     double dU   = Ui - Ui_1;    // Incremental deformation at current step
-    double exKgetTangent = KgetTangent;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////  MAIN CODE //////////////////////////////////////////////////////////
@@ -164,7 +162,6 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
             FailK           = (betaK>1);
             betaK           = betaK < 0 ? 0 : (betaK>1 ? 1 : betaK);
             Kunload         *= (1 - betaK);
-            KgetTangent     = Kunload;
         }
         Fi	    = Fi_1 + Kunload * dU;
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -228,7 +225,7 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
             // When a part of backbone is beneath the residual strength
             // Global Peak on the Updated Backbone
                 if (negUy < negUglobal) {           // Elastic Branch
-                    negFglobal	= Ke * negUglobal; 
+                    negFglobal	= Ke * negUglobal;
                 }
                 else if (negUcap < negUglobal) {    // Post-Yield Branch
                     negFglobal	= negFy   + negKp  * (negUglobal - negUy);
@@ -266,7 +263,6 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
                     Kreload = Kglobal;
                 }
             }
-            KgetTangent = Kreload;
         }
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -290,55 +286,43 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
         // int exBranch = Branch;
         if (Branch == 0 && Ui > posUy) {            // Yield in Positive
             Branch  = 5;
-            KgetTangent = posKp;
         } else if (Branch == 0 && Ui < negUy) {     // Yield in Negative
             Branch  = 15;
-            KgetTangent = negKp;
         } else if (Branch == 1 && Fi_1 > 0 && Ui > posUlocal) {
             double Kglobal = (posFglobal   - posFlocal) / (posUglobal  - posUlocal);
             Kreload = Kglobal;
             Branch  = 4;                        // Towards Global Peak
-            KgetTangent = Kreload;
         } else if (Branch == 1 && Fi_1 < 0 && Ui < negUlocal) {    // Back to Reloading (Negative)
             double Kglobal = (negFglobal   - negFlocal) / (negUglobal  - negUlocal);
             Kreload = Kglobal;
             Branch  = 14;                   // Towards Global Peak
-            KgetTangent = Kreload;
         }
     // Positive
         if (Branch == 3 && Ui > posUlocal) {
             Kreload     = (posFglobal - posFlocal) / (posUglobal - posUlocal);
-            KgetTangent = Kreload;
             Branch      = 4;
         }
         if (Branch == 4 && Ui > posUglobal) {
-            KgetTangent = posKp;
             Branch 	    = 5;
         }
         if (Branch == 5 && Ui > posUcap) {
-            KgetTangent = posKpc;
             Branch 	    = 6;
         }
         if (Branch == 6 && Ui > posUres) {
-            KgetTangent = 0;
             Branch 	    = 7;
         }
     // Negative
         if (Branch == 13 && Ui < negUlocal) {
             Kreload     = (negFglobal - negFlocal) / (negUglobal - negUlocal);
-            KgetTangent = Kreload;
             Branch      = 14;
         }
         if (Branch == 14 && Ui < negUglobal) {
-            KgetTangent = negKp;
             Branch 	    = 15;
         }
         if (Branch == 15 && Ui < negUcap) {
-            KgetTangent = negKpc;
             Branch 	    = 16;
         }
         if (Branch == 16 && Ui < negUres) {
-            KgetTangent = 0;
             Branch 	    = 17;
         }
     // Branch Change check
@@ -395,9 +379,7 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
 
         engAcml += 0.5*(Fi + Fi_1)*dU;   // Internal energy increment
 
-        if (KgetTangent!=exKgetTangent) {
-            KgetTangent  = (Fi - Fi_1) / dU;
-        }
+        KgetTangent  = (Fi - Fi_1) / dU;
     }
     if (KgetTangent==0) {
         KgetTangent  = 1e-6;
@@ -407,13 +389,13 @@ int IMKPeakOriented::setTrialStrain(double strain, double strainRate)
 ////////////////////////////////////////////// END OF MAIN CODE ///////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-	return 0;
+    return 0;
 }
 
 double IMKPeakOriented::getStress(void)
 {
-	//cout << " getStress" << endln;
-	return (Fi);
+    //cout << " getStress" << endln;
+    return (Fi);
 }
 
 double IMKPeakOriented::getTangent(void)
@@ -424,19 +406,19 @@ double IMKPeakOriented::getTangent(void)
 
 double IMKPeakOriented::getInitialTangent(void)
 {
-	//cout << " getInitialTangent" << endln;
-	return (Ke);
+    //cout << " getInitialTangent" << endln;
+    return (Ke);
 }
 
 double IMKPeakOriented::getStrain(void)
 {
-	//cout << " getStrain" << endln;
-	return (U);
+    //cout << " getStrain" << endln;
+    return (U);
 }
 
 int IMKPeakOriented::commitState(void)
 {
-	//cout << " commitState" << endln;
+    //cout << " commitState" << endln;
 
     //commit trial  variables
 // 12 Pos U and F
@@ -516,7 +498,7 @@ int IMKPeakOriented::revertToLastCommit(void)
     Ui	            = cUi;
     Fi	            = cFi;
 // 2 Stiffness
-    Kreload	    = cKreload;
+    Kreload	        = cKreload;
     Kunload	        = cKunload;
 // 2 Energy
     engAcml	        = cEngAcml;
@@ -578,8 +560,9 @@ int IMKPeakOriented::revertToStart(void)
     Ui      	= cUi 	        = 0;
     Fi 	        = cFi 	        = 0;
 // 2 Stiffness
-    Kreload	= cKreload	    = Ke;
+    Kreload	    = cKreload	    = Ke;
     Kunload	    = cKunload	    = Ke;
+    KgetTangent = Ke;
 // 2 Energy
     engAcml 	= cEngAcml	    = 0.0;
     engDspt	    = cEngDspt	    = 0.0;
@@ -629,7 +612,7 @@ IMKPeakOriented::getCopy(void)
     theCopy->Ui         = Ui;
     theCopy->Fi         = Fi;
 // 2 Stiffness
-    theCopy->Kreload   = Kreload;
+    theCopy->Kreload    = Kreload;
     theCopy->Kunload    = Kunload;
 // 2 Energy
     theCopy->engAcml    = engAcml;
@@ -668,7 +651,7 @@ IMKPeakOriented::getCopy(void)
     theCopy->cUi        = cUi;
     theCopy->cFi        = cFi;
 // 2 Stiffness
-    theCopy->cKreload  = cKreload;
+    theCopy->cKreload   = cKreload;
     theCopy->cKunload   = cKunload;
 // 2 Energy
     theCopy->cEngAcml   = cEngAcml;
@@ -681,8 +664,8 @@ IMKPeakOriented::getCopy(void)
 
 int IMKPeakOriented::sendSelf(int cTag, Channel &theChannel)
 {
-	int res = 0;
-	cout << " sendSelf" << endln;
+    int res = 0;
+    cout << " sendSelf" << endln;
 
     static Vector data(137);
     data(0) = this->getTag();
@@ -806,14 +789,14 @@ int IMKPeakOriented::sendSelf(int cTag, Channel &theChannel)
     res = theChannel.sendVector(this->getDbTag(), cTag, data);
     if (res < 0)
         opserr << "IMKPeakOriented::sendSelf() - failed to send data\n";
-	return res;
+    return res;
 }
 
 int IMKPeakOriented::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
 {
-	int res = 0;
-	static Vector data(137);
-	res = theChannel.recvVector(this->getDbTag(), cTag, data);
+    int res = 0;
+    static Vector data(137);
+    res = theChannel.recvVector(this->getDbTag(), cTag, data);
 
     if (res < 0) {
         opserr << "IMKPeakOriented::recvSelf() - failed to receive data\n";
@@ -941,10 +924,10 @@ int IMKPeakOriented::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &t
         cBranch			= data(136);
     }
 
-	return res;
+    return res;
 }
 
 void IMKPeakOriented::Print(OPS_Stream &s, int flag)
 {
-	cout << "IMKPeakOriented tag: " << this->getTag() << endln;
+    cout << "IMKPeakOriented tag: " << this->getTag() << endln;
 }

--- a/C++ Code/IMKPinching.cpp
+++ b/C++ Code/IMKPinching.cpp
@@ -39,24 +39,24 @@ static int numIMKPinchingMaterials = 0;
 void *
 OPS_IMKPinching()
 {
-	if (numIMKPinchingMaterials == 0) {
-		numIMKPinchingMaterials++;
-		OPS_Error("IMK with Pinched Response - Code by AE_KI (Oct22)\n", 1);
-	}
+    if (numIMKPinchingMaterials == 0) {
+        numIMKPinchingMaterials++;
+        opserr << "IMK with Pinched Response - Code by AE_KI (Nov22)\n";
+    }
 
-	// Pointer to a uniaxial material that will be returned
-	UniaxialMaterial *theMaterial = 0;
+    // Pointer to a uniaxial material that will be returned
+    UniaxialMaterial *theMaterial = 0;
 
-	int    iData[1];
-	double dData[25];
-	int numData = 1;
+    int    iData[1];
+    double dData[25];
+    int numData = 1;
 
-	if (OPS_GetIntInput(&numData, iData) != 0) {
-		opserr << "WARNING invalid uniaxialMaterial IMKPinching tag" << endln;
-		return 0;
-	}
+    if (OPS_GetIntInput(&numData, iData) != 0) {
+        opserr << "WARNING invalid uniaxialMaterial IMKPinching tag" << endln;
+        return 0;
+    }
 
-	numData = 25;
+    numData = 25;
 
 
     if (OPS_GetDoubleInput(&numData, dData) != 0) {
@@ -68,21 +68,20 @@ OPS_IMKPinching()
     }
 
 
+    // Parsing was successful, allocate the material
+    theMaterial = new IMKPinching(iData[0],
+        dData[0],
+        dData[1], dData[2], dData[3], dData[4], dData[5], dData[6],
+        dData[7], dData[8], dData[9], dData[10], dData[11], dData[12],
+        dData[13], dData[14], dData[15], dData[16], dData[17], dData[18], dData[19], dData[20],
+        dData[21], dData[22],dData[23], dData[24]);
 
-	// Parsing was successful, allocate the material
-	theMaterial = new IMKPinching(iData[0],
-		dData[0],
-		dData[1], dData[2], dData[3], dData[4], dData[5], dData[6],
-		dData[7], dData[8], dData[9], dData[10], dData[11], dData[12],
-		dData[13], dData[14], dData[15], dData[16], dData[17], dData[18], dData[19], dData[20],
-		dData[21], dData[22],dData[23], dData[24]);
+    if (theMaterial == 0) {
+        opserr << "WARNING could not create uniaxialMaterial of type IMKPinching Material\n";
+        return 0;
+    }
 
-	if (theMaterial == 0) {
-		opserr << "WARNING could not create uniaxialMaterial of type IMKPinching Material\n";
-		return 0;
-	}
-
-	return theMaterial;
+    return theMaterial;
 }
 
 IMKPinching::IMKPinching(int tag, double p_Ke,
@@ -94,7 +93,7 @@ IMKPinching::IMKPinching(int tag, double p_Ke,
     negUp_0(p_negUp_0), negUpc_0(p_negUpc_0), negUu_0(p_negUu_0), negFy_0(p_negFy_0), negFcapFy_0(p_negFcapFy_0), negFresFy_0(p_negFresFy_0),
     LAMBDA_S(p_LAMBDA_S), LAMBDA_C(p_LAMBDA_C), LAMBDA_A(p_LAMBDA_A), LAMBDA_K(p_LAMBDA_K), c_S(p_c_S), c_C(p_c_C), c_A(p_c_A), c_K(p_c_K), D_pos(p_D_pos), D_neg(p_D_neg), kappaF(p_kappaF), kappaD(p_kappaD)
 {
-	this->revertToStart();
+    this->revertToStart();
 }
 
 IMKPinching::IMKPinching()
@@ -103,18 +102,18 @@ IMKPinching::IMKPinching()
     negUp_0(0), negUpc_0(0), negUu_0(0), negFy_0(0), negFcapFy_0(0), negFresFy_0(0),
     LAMBDA_S(0), LAMBDA_C(0), LAMBDA_A(0), LAMBDA_K(0), c_S(0), c_C(0), c_A(0), c_K(0), D_pos(0), D_neg(0), kappaF(0), kappaD(0)
 {
-	this->revertToStart();
+    this->revertToStart();
 }
 
 IMKPinching::~IMKPinching()
 {
-	// does nothing
+    // does nothing
 }
 
 int IMKPinching::setTrialStrain(double strain, double strainRate)
 {
-	//all variables to the last commit
-	this->revertToLastCommit();
+    //all variables to the last commit
+    this->revertToLastCommit();
 
     //state determination algorithm: defines the current force and tangent stiffness
     double Ui_1 = Ui;
@@ -122,7 +121,6 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
     U           = strain; //set trial displacement
     Ui          = U;
     double dU   = Ui - Ui_1;    // Incremental deformation at current step
-    double exKgetTangent = KgetTangent;
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////  MAIN CODE //////////////////////////////////////////////////////////
@@ -164,7 +162,6 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
             FailK           = (betaK>1);
             betaK           = betaK < 0 ? 0 : (betaK>1 ? 1 : betaK);
             Kunload         *= (1 - betaK);
-            KgetTangent     = Kunload;
         }
         Fi	    = Fi_1 + Kunload * dU;
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -228,7 +225,7 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
             // When a part of backbone is beneath the residual strength
             // Global Peak on the Updated Backbone
                 if (negUy < negUglobal) {           // Elastic Branch
-                    negFglobal	= Ke * negUglobal; 
+                    negFglobal	= Ke * negUglobal;
                 }
                 else if (negUcap < negUglobal) {    // Post-Yield Branch
                     negFglobal	= negFy   + negKp  * (negUglobal - negUy);
@@ -280,7 +277,6 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
                     Kreload = Kglobal;
                 }
             }
-            KgetTangent = Kreload;
          }
     ///////////////////////////////////////////////////////////////////////////////////////////
     ///////////////////////////////////////////////////////////////////////////////////////////
@@ -306,10 +302,8 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
         // int exBranch = Branch;
         if (Branch == 0 && Ui > posUy) {            // Yield in Positive
             Branch  = 5;
-            KgetTangent = posKp;
         } else if (Branch == 0 && Ui < negUy) {     // Yield in Negative
             Branch  = 15;
-            KgetTangent = negKp;
         } else if (Branch == 1 && Fi_1 > 0 && Ui > posUlocal) {
             double Kpinch  = (Fpinch       - posFlocal) / (Upinch      - posUlocal);
             double Kglobal = (posFglobal   - posFlocal) / (posUglobal  - posUlocal);
@@ -320,7 +314,6 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
                 Kreload = Kglobal;
                 Branch  = 4;                        // Towards Global Peak
             }
-            KgetTangent = Kreload;
         } else if (Branch == 1 && Fi_1 < 0 && Ui < negUlocal) {    // Back to Reloading (Negative)
             double Kpinch  = (Fpinch       - negFlocal) / (Upinch      - negUlocal);
             double Kglobal = (negFglobal   - negFlocal) / (negUglobal  - negUlocal);
@@ -331,7 +324,6 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
                 Kreload = Kglobal;
                 Branch  = 14;                   // Towards Global Peak
             }
-            KgetTangent = Kreload;
         }
     // Positive
         if (Branch == 2 && Ui > Upinch) {
@@ -344,23 +336,18 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
                 Kreload = Kglobal;
                 Branch 	= 4;
             }
-            KgetTangent = Kreload;
         }
         if (Branch == 3 && Ui > posUlocal) {
             Kreload     = (posFglobal - posFlocal) / (posUglobal - posUlocal);
-            KgetTangent = Kreload;
             Branch      = 4;
         }
         if (Branch == 4 && Ui > posUglobal) {
-            KgetTangent = posKp;
             Branch 	    = 5;
         }
         if (Branch == 5 && Ui > posUcap) {
-            KgetTangent = posKpc;
             Branch 	    = 6;
         }
         if (Branch == 6 && Ui > posUres) {
-            KgetTangent = 0;
             Branch 	    = 7;
         }
     // Negative
@@ -374,23 +361,18 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
                 Kreload = Kglobal;
                 Branch 	= 14;
             }
-            KgetTangent = Kreload;
         }
         if (Branch == 13 && Ui < negUlocal) {
             Kreload     = (negFglobal - negFlocal) / (negUglobal - negUlocal);
-            KgetTangent = Kreload;
             Branch      = 14;
         }
         if (Branch == 14 && Ui < negUglobal) {
-            KgetTangent = negKp;
             Branch 	    = 15;
         }
         if (Branch == 15 && Ui < negUcap) {
-            KgetTangent = negKpc;
             Branch 	    = 16;
         }
         if (Branch == 16 && Ui < negUres) {
-            KgetTangent = 0;
             Branch 	    = 17;
         }
     // Branch Change check
@@ -451,9 +433,7 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
 
         engAcml += 0.5*(Fi + Fi_1)*dU;   // Internal energy increment
 
-        if (KgetTangent!=exKgetTangent) {
-            KgetTangent  = (Fi - Fi_1) / dU;
-        }
+        KgetTangent  = (Fi - Fi_1) / dU;
     }
     if (KgetTangent==0) {
         KgetTangent  = 1e-6;
@@ -468,8 +448,8 @@ int IMKPinching::setTrialStrain(double strain, double strainRate)
 
 double IMKPinching::getStress(void)
 {
-	//cout << " getStress" << endln;
-	return (Fi);
+    //cout << " getStress" << endln;
+    return (Fi);
 }
 
 double IMKPinching::getTangent(void)
@@ -480,19 +460,19 @@ double IMKPinching::getTangent(void)
 
 double IMKPinching::getInitialTangent(void)
 {
-	//cout << " getInitialTangent" << endln;
-	return (Ke);
+    //cout << " getInitialTangent" << endln;
+    return (Ke);
 }
 
 double IMKPinching::getStrain(void)
 {
-	//cout << " getStrain" << endln;
-	return (U);
+    //cout << " getStrain" << endln;
+    return (U);
 }
 
 int IMKPinching::commitState(void)
 {
-	//cout << " commitState" << endln;
+    //cout << " commitState" << endln;
 
     //commit trial  variables
 // 12 Pos U and F
@@ -640,8 +620,9 @@ int IMKPinching::revertToStart(void)
     Ui      	= cUi 	        = 0;
     Fi 	        = cFi 	        = 0;
 // 2 Stiffness
-    Kreload	= cKreload	    = Ke;
+    Kreload	    = cKreload	    = Ke;
     Kunload	    = cKunload	    = Ke;
+    KgetTangent = Ke;
 // 2 Energy
     engAcml 	= cEngAcml	    = 0.0;
     engDspt	    = cEngDspt	    = 0.0;
@@ -695,7 +676,7 @@ IMKPinching::getCopy(void)
     theCopy->Ui         = Ui;
     theCopy->Fi         = Fi;
 // 2 Stiffness
-    theCopy->Kreload   = Kreload;
+    theCopy->Kreload    = Kreload;
     theCopy->Kunload    = Kunload;
 // 2 Energy
     theCopy->engAcml    = engAcml;
@@ -734,7 +715,7 @@ IMKPinching::getCopy(void)
     theCopy->cUi        = cUi;
     theCopy->cFi        = cFi;
 // 2 Stiffness
-    theCopy->cKreload  = cKreload;
+    theCopy->cKreload   = cKreload;
     theCopy->cKunload   = cKunload;
 // 2 Energy
     theCopy->cEngAcml   = cEngAcml;
@@ -750,8 +731,8 @@ IMKPinching::getCopy(void)
 
 int IMKPinching::sendSelf(int cTag, Channel &theChannel)
 {
-	int res = 0;
-	cout << " sendSelf" << endln;
+    int res = 0;
+    cout << " sendSelf" << endln;
 
     static Vector data(137);
     data(0) = this->getTag();
@@ -883,7 +864,7 @@ int IMKPinching::sendSelf(int cTag, Channel &theChannel)
     res = theChannel.sendVector(this->getDbTag(), cTag, data);
     if (res < 0)
         opserr << "IMKPinching::sendSelf() - failed to send data\n";
-	return res;
+    return res;
 }
 
 int IMKPinching::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBroker)
@@ -1026,10 +1007,10 @@ int IMKPinching::recvSelf(int cTag, Channel &theChannel, FEM_ObjectBroker &theBr
         cBranch			= data(136);
     }
 
-	return res;
+    return res;
 }
 
 void IMKPinching::Print(OPS_Stream &s, int flag)
 {
-	cout << "IMKPinching tag: " << this->getTag() << endln;
+    cout << "IMKPinching tag: " << this->getTag() << endln;
 }


### PR DESCRIPTION
"OPS_Error" returns a warning when building and other sections are using "opserr <<". Then, each "OPS_Error"s used for "IMK with ... Response - Code by AE_KI (Nov22)" are replaced. 
"KgetTangent"s will be calculated based on force increment and displacement increment at every step, which is also noted in the pull request in OpenSees. This will improve convergence problems in static pushover analysis and a consistency in IDA curve. We can't see why it happens in spring responses, but it seems to be the best way to calculate tangent stiffnesses. 
Then, Oct22 will be replaced by Nov22 now.